### PR TITLE
chore: Fix versionningTemplate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,7 @@
       matchStrings: ["ENV IPERF_VERSION (?<currentValue>.*)\\n"],
       datasourceTemplate: "github-tags",
       depNameTemplate: "esnet/iperf",
+      versioningTemplate: "semver-coerced",
     },
   ],
 }


### PR DESCRIPTION
The default [Semantic Versioning](https://docs.renovatebot.com/modules/versioning/#semantic-versioning) does not recognize a patch version unless it is written.
Therefore, [Coerced Semantic Versioning](https://docs.renovatebot.com/modules/versioning/#coerced-semantic-versioning-versioning) is used.